### PR TITLE
Do not consider edge clicks when calculating emulated buttons

### DIFF
--- a/src/gestures.c
+++ b/src/gestures.c
@@ -312,10 +312,11 @@ static void buttons_update(struct Gestures* gs,
 				foreach_bit(i, ms->touch_used) {
 					timeraddms(&ms->touch[i].down, cfg->button_expire, &expire);
 					if ((cfg->button_move || cfg->button_expire == 0 || timercmp(&ms->touch[latest].down, &expire, <)) &&
-                            !(GETBIT(ms->touch[i].state, MT_THUMB) && cfg->ignore_thumb) &&
-                            !(GETBIT(ms->touch[i].state, MT_PALM) && cfg->ignore_palm)) {
+						!(GETBIT(ms->touch[i].state, MT_THUMB) && cfg->ignore_thumb) &&
+						!(GETBIT(ms->touch[i].state, MT_PALM) && cfg->ignore_palm) &&
+						!(GETBIT(ms->touch[i].state, MT_EDGE))) {
 						touching++;
-                    }
+					}
 				}
 
 				if (cfg->button_integrated)
@@ -1131,4 +1132,3 @@ int gestures_delayed(struct MTouch* mt)
 	gs->move_dx = gs->move_dy = 0;
 	return -MT_TIMER_DELAYED_BUTTON; /* remove delayed button timer */
 }
-


### PR DESCRIPTION
Fix #18 

This prevents fingers that are located in the edge area from being considered part of a 2- or 3-finger click. This fixes an annoying behavior on touch pads with integrated buttons, where moving one finger near the center of the touch pad and clicking with the thumb near the bottom of the touch pad would be considered a 2-finger click.

I believe this behavior will make a lot more sense for users with large touch pads, like the ones on Apple laptops and Surface Book laptops. 

@p2rkw 