### PR TITLE
Add option to handle on "Edge" click

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 *.lo
 *.la
 *.swp
+*.dirstamp
 .deps/
 .libs/
 Makefile
@@ -20,5 +21,10 @@ ltmain.sh
 /stamp-h1
 /depcomp
 /compile
+
+debian/files
+debian/xserver-xorg-input-mtrack.debhelper.log
+debian/xserver-xorg-input-mtrack.substvars
+debian/xserver-xorg-input-mtrack/
 
 mtrack-test

--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ value of 0 will not expire touches. Integer value. Defaults to 100.
 <a name="ClickFinger0"></a>
 **ClickFinger0** - 
 Which button to emulate when no valid finger placement is touching the trackpad during a
-click. Integer value. A value of 0 disables one-touch emulation. Defaults to 0.
+click, as on "EdgeBottom". Integer value. A value of 0 disables one-touch emulation. Defaults to 0.
 
 <a name="ClickFinger1"></a>
 **ClickFinger1** - 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Available options and their defaults are as follows.
 
 [ButtonTouchExpire](#ButtonTouchExpire)
 
+[ClickFinger0](#ClickFinger0) &nbsp;&nbsp;&nbsp;
 [ClickFinger1](#ClickFinger1) &nbsp;&nbsp;&nbsp;
 [ClickFinger2](#ClickFinger2) &nbsp;&nbsp;&nbsp;
 [ClickFinger3](#ClickFinger3) &nbsp;&nbsp;&nbsp;
@@ -311,6 +312,11 @@ ClickFinger3. Boolean value. Defaults to false.
 **ButtonTouchExpire** - 
 How long (in ms) to consider a touching finger as part of button emulation. A
 value of 0 will not expire touches. Integer value. Defaults to 100.
+
+<a name="ClickFinger0"></a>
+**ClickFinger0** - 
+Which button to emulate when no valid finger placement is touching the trackpad during a
+click. Integer value. A value of 0 disables one-touch emulation. Defaults to 0.
 
 <a name="ClickFinger1"></a>
 **ClickFinger1** - 
@@ -669,6 +675,13 @@ easier by enabling persistent tap-to-drag:
 With that change you will have to perform additional tap when dragging with
 tap-to-drag. Other positive values will let you continue yor drag within
 specified time.
+
+##### Enabling soft button
+If you enable edge restriction an you still want the integrated button to click inside that edge, you must enable ClickFinger0.
+```
+    Option "ClickFinger0" "1"
+```
+You can also set another button instead of "1".
 
 [1]: http://www.kernel.org/doc/Documentation/input/multi-touch-protocol.txt     "Kernel Multitouch Protocol"
 [2]: http://www.gnu.org/licenses/gpl-2.0.html                                   "GNU General Public License, version 2"

--- a/driver/mprops.c
+++ b/driver/mprops.c
@@ -158,10 +158,11 @@ void mprops_init(struct MConfig* cfg, InputInfoPtr local) {
 	ivals[2] = cfg->button_expire;
 	mprops.button_emulate_settings = atom_init_integer(local->dev, MTRACK_PROP_BUTTON_EMULATE_SETTINGS, 3, ivals, 16);
 
-	ivals[0] = cfg->button_1touch;
-	ivals[1] = cfg->button_2touch;
-	ivals[2] = cfg->button_3touch;
-	mprops.button_emulate_values = atom_init_integer(local->dev, MTRACK_PROP_BUTTON_EMULATE_VALUES, 3, ivals, 8);
+	ivals[0] = cfg->button_0touch;
+	ivals[1] = cfg->button_1touch;
+	ivals[2] = cfg->button_2touch;
+	ivals[3] = cfg->button_3touch;
+	mprops.button_emulate_values = atom_init_integer(local->dev, MTRACK_PROP_BUTTON_EMULATE_VALUES, 4, ivals, 8);
 
 	ivals[0] = cfg->tap_hold;
 	ivals[1] = cfg->tap_timeout;
@@ -414,19 +415,20 @@ int mprops_set_property(DeviceIntPtr dev, Atom property, XIPropertyValuePtr prop
 		}
 	}
 	else if (property == mprops.button_emulate_values) {
-		if (prop->size != 3 || prop->format != 8 || prop->type != XA_INTEGER)
+		if (prop->size != 4 || prop->format != 8 || prop->type != XA_INTEGER)
 			return BadMatch;
 
 		ivals8 = (uint8_t*)prop->data;
-		if (!VALID_BUTTON(ivals8[0]) || !VALID_BUTTON(ivals8[1]) || !VALID_BUTTON(ivals8[2]))
+		if (!VALID_BUTTON(ivals8[0]) || !VALID_BUTTON(ivals8[1]) || !VALID_BUTTON(ivals8[2]) || !VALID_BUTTON(ivals8[3]))
 			return BadMatch;
 
 		if (!checkonly) {
-			cfg->button_1touch = ivals8[0];
-			cfg->button_2touch = ivals8[1];
-			cfg->button_3touch = ivals8[2];
-			LOG_DEBUG_PROPS("set button emulation to %d %d %d\n",
-				cfg->button_1touch, cfg->button_2touch, cfg->button_3touch);
+			cfg->button_0touch = ivals8[0];
+			cfg->button_1touch = ivals8[1];
+			cfg->button_2touch = ivals8[2];
+			cfg->button_3touch = ivals8[3];
+			LOG_DEBUG_PROPS("set button emulation to %d %d %d %d\n",
+				cfg->button_0touch, cfg->button_1touch, cfg->button_2touch, cfg->button_3touch);
 		}
 	}
 	else if (property == mprops.tap_settings) {

--- a/examples/asus-zenbook-ux330ua-ah55
+++ b/examples/asus-zenbook-ux330ua-ah55
@@ -1,0 +1,125 @@
+# mtrack config made for asus-zenbook-ux330ua-ah55 
+
+###--------------------------------------------------------------------------###
+# Properties in comments are "xinput set-prop" command to enable setting live (without restarting X)
+# Refer to source code to read more about those: xf86-input-mtrack/include/mprops.h
+###--------------------------------------------------------------------------###
+
+
+Section "InputClass"
+        MatchIsTouchpad "on"
+        Identifier "Touchpads"
+        Driver "mtrack"
+        Option "DeviceEnabled" "1"
+
+###--------------------------------------------------------------------------###
+###   http://www.x.org/wiki/Development/Documentation/PointerAcceleration/
+###   Base velocity setting
+###   Options for polynomial("2") profile
+###--------------------------------------------------------------------------###
+        Option "AccelerationProfile" "4"
+        Option "Sensitivity" "0.75" # Adjusts the sensitivity (movement speed) of the touchpad. This is a real number greater than or equal to zero. Default is 1. A value of 0 will disable pointer movement.
+        Option "AdaptiveDeceleration" "2.0"
+        Option "ConstantDeceleration" "1.02"
+        Option "VelocityScale" "1.0"
+
+###---------------------------------------------------------------------------###
+###   Ignore certain touch type
+###---------------------------------------------------------------------------###
+        Option "PalmSize" "30" # The minimum size of what's considered a palm. Palms are expected to be very large on the trackpad. This is represented as a percentage of the maximum touch value and is dependent on the trackpad hardware. Integer value. Defaults to 40.
+        Option "IgnorePalm" "true" # Whether or not to ignore touches that are determined to be palms. Boolean value. Defaults to false.
+        Option "DisableOnPalm" "true" # Whether or not to disable the entire trackpad when a palm is touching. Boolean value. Defaults to false.
+
+        Option "IgnoreThumb" "true" # Whether or not to ignore touches that are determined to be thumbs. Boolean value. Defaults to false.
+        Option "ThumbRatio" "70" # The width/length ratio of what's considered a thumb. It is expected that a thumb is longer than it is wide. This tells the driver how much longer. Percentage represented by an integer. Defaults to 70.
+        Option "ThumbSize" "15" # The minimum size of what's considered a thumb. It is expected that a thumb will be larger than other fingers. This is represented as a percentage of the maximum touch value and is dependent on the trackpad hardware. Integer value. Defaults to 25.
+
+###--------------------------------------------------------------------------###
+###   Set click interactions
+###--------------------------------------------------------------------------###
+        Option "ButtonEnable" "true" # Whether or not to enable the physical buttons on or near the trackpad. Boolean value. Defaults to true.
+        Option "ButtonMoveEmulate" "true" # Whether or not to count the moving finger when emulating button clicks. Useful to disable if you use two hands on trackpad. Boolean value. Defaults to true.
+        Option "ButtonIntegrated" "true" # Whether or not the physical buttons are integrated with the trackpad. If you have a one-piece trackpad like on newer MacBooks, this should be set to true. Button emulation depends on this value being correct. Boolean value. Defaults to true.
+        Option "ButtonZonesEnable" "false" # Whether or not to enable button zones. If button zones are enabled then the trackpad will be split into one, two, or three vertical zones. Clicking the integrated button in one of these zones will send the button event for ClickFinger1, ClickFinger2, or ClickFinger3. The driver will only add zones for those ClickFinger values that are enabled. So setting ClickFinger1 to 0 and enabling the other two will create two zones, one for ClickFinger2 and one for ClickFinger3. Boolean value. Defaults to false.
+
+        Option "ClickFinger0" "1" # Which button to emulate when no valid finger placement is touching the trackpad during a click. Integer value. A value of 0 disables one-touch emulation. Defaults to 1.
+        Option "ClickFinger1" "1" # Which button to emulate when one finger is touching the trackpad during a click. Integer value. A value of 0 disables one-touch emulation. Defaults to 1.
+        Option "ClickFinger2" "1" # Which button to emulate when two fingers are touching the trackpad during a click. Integer value. A value of 0 disabled one-touch emulation. Defaults to 2.
+        Option "ClickFinger3" "2" # Which button to emulate when three fingers are touching the trackpad during a click. Integer value. A value of 0 disabled one-touch emulation. Defaults to 3.
+
+###---------------------- Gesture Settings ----------------------------------###
+### property: "Trackpad Gesture Settings"
+        Option "GestureClickTime" "20"
+        Option "GestureWaitTime" "3"
+###--------------------------------------------------------------------------###
+
+        Option "ButtonTouchExpire" "120"
+        
+        Option "FingerLow" "0" # Defines the pressure at which a finger is detected as a release. This is a percentage represented as an integer. Default is 5.
+        Option "FingerHigh" "0" # Defines the pressure at which a finger is detected as a touch. This is a percentage represented as an integer. Default is 5.
+
+###---------------------- Tap Settings --------------------------------------###
+### property "Trackpad Tap Settings"
+        Option "ClickTime" "15" # When tapping, how much time to hold down the emulated button. Integer value representing milliseconds. Integer value representing miliseconds. Defaults to 50.
+        Option "MaxTapTime" "165"
+        Option "MaxTapMove" "155"
+###--------------------------------------------------------------------------###
+
+        Option "TapButton1" "1"
+        Option "TapButton2" "3"
+        Option "TapButton3" "2"
+
+###------------------------ Swipe2 as mouse wheel ---------------------------###
+        Option "ScrollSensitivity" "0" # disable pointer mouvement during scroll 
+        Option "ScrollDistance" "22"
+        Option "ScrollClickTime" "12"
+        Option "ScrollSensitivity" "0"
+        Option "ScrollUpButton" "5"
+        Option "ScrollDownButton" "4"
+        Option "ScrollLeftButton" "6"
+        Option "ScrollRightButton" "7"
+
+###--------------------------------------------------------------------------###
+        Option "SwipeDistance" "22"
+        Option "SwipeClickTime" "12"
+        
+### property: "Trackpad Swipe Buttons"
+        Option "SwipeUpButton" "4"
+        Option "SwipeDownButton" "5"
+        Option "SwipeLeftButton" "6"
+        Option "SwipeRightButton" "7"
+###--------------------------------------------------------------------------###
+
+###---------------------- Swipe4 to drag buttons 9 10 11 12 -----------------###
+        Option "Swipe4Distance" "280"
+        Option "Swipe4ClickTime" "50"
+        Option "Swipe4Sensitivity" "0"
+## property: "Trackpad Swipe4 Buttons"
+        Option "Swipe4UpButton" "9"
+        Option "Swipe4DownButton" "10"
+        Option "Swipe4LeftButton" "11"
+        Option "Swipe4RightButton" "12"
+###--------------------------------------------------------------------------###
+
+        Option "ScaleDistance" "70"
+        Option "ScaleUpButton" "12"
+        Option "ScaleDownButton" "13"
+
+        Option "RotateDistance" "350"
+        Option "RotateLeftButton" "14"
+        Option "RotateRightButton" "15"
+
+###--------------------------------------------------------------------------###
+### xinput set-prop 11 "Trackpad Drag Settings" 1 350 60 200
+        Option "TapDragEnable" "true"
+        Option "TapDragTime" "350"
+        Option "TapDragWait" "40"
+        Option "TapDragDist" "150"
+        Option "TapDragLockTimeout" "0" # This is how long the driver will wait after initial drag in 'drag ready' state in which it will be able to resume previous drag without additional up, down sequence. Value of 0 disables this functionality. Values less than zero will make mtrack requre additional tap to finish drag by sending button up. Integer value representing milliseconds. Defaults to 500.
+###--------------------------------------------------------------------------###
+
+        Option "EdgeBottomSize"        "17"  # dont count touches from bottom 17% of area
+
+        Option "Hold1Move1StationaryMaxMove" "120"
+        Option "Hold1Move1StationaryButton" "1" # For two finger hold-and-move functionality. The button that is triggered by holding one finger and moving another one. Integer value. A value of 0 disables hold-and-move. Value of 0 disables this functionality. Defaults to 1.
+EndSection

--- a/include/mconfig.h
+++ b/include/mconfig.h
@@ -41,6 +41,7 @@
 #define DEFAULT_BUTTON_ENABLE 1
 #define DEFAULT_BUTTON_INTEGRATED 1
 #define DEFAULT_BUTTON_ZONES 0
+#define DEFAULT_BUTTON_0TOUCH 0 /* When finger placement is "invalid", do not emulate any button */
 #define DEFAULT_BUTTON_1TOUCH 1
 #define DEFAULT_BUTTON_2TOUCH 2
 #define DEFAULT_BUTTON_3TOUCH 3
@@ -156,6 +157,8 @@ struct MConfig {
 	int button_integrated;	// Is the button under the touchpad? 0 or 1
 	int button_expire;		// How long to consider a touch for button emulation. >= 0
 	int button_zones;		// Use button zones for emulation?
+	int button_0touch;		// What button to emulate when no finger is on the
+							// pad and a click is registered? 0 to 32
 	int button_1touch;		// What button to emulate when one finger is on the
 							// pad or the first zone is clicked? 0 to 32
 	int button_2touch;		// What button to emulate when two fingers are on the

--- a/include/mprops.h
+++ b/include/mprops.h
@@ -46,7 +46,7 @@
 #define MTRACK_PROP_BUTTON_SETTINGS "Trackpad Button Settings"
 // int, 3 values - enable button zones, button move emulation, emulation touch expiration
 #define MTRACK_PROP_BUTTON_EMULATE_SETTINGS "Trackpad Button Emulation Settings"
-// int, 3 values - button to emulate with 1 touch, 2 touches, 3 touches
+// int, 4 values - button to emulate with 0 touch, 1 touch, 2 touches, 3 touches
 #define MTRACK_PROP_BUTTON_EMULATE_VALUES "Trackpad Button Emulation Values"
 // int, 3 values - click time, touch timeout, invalidate distance
 #define MTRACK_PROP_TAP_SETTINGS "Trackpad Tap Settings"

--- a/src/gestures.c
+++ b/src/gestures.c
@@ -272,7 +272,7 @@ static void buttons_update(struct Gestures* gs,
 	button_prev = hs->button;
 
 	if (integrated_down) {
-		int earliest, latest, lowest = 0;
+		int earliest, latest, lowest;
 		gs->move_type = GS_NONE;
 		timeraddms(&gs->time, cfg->gesture_wait, &gs->move_wait);
 		earliest = -1;
@@ -283,7 +283,7 @@ static void buttons_update(struct Gestures* gs,
 				continue;
 			if (cfg->button_integrated)
 				SETBIT(ms->touch[i].flags, MT_BUTTON); /* Mark all existing touches as physical button press */
-			if (lowest == -1 || ms->touch[i].y > ms->touch[lowest].y)
+			if (lowest == -1 || ms->touch[i].y > ms->touch[lowest].y) /* The logic/naming seems to be inverted here */
 				lowest = i;
 			if (earliest == -1 || timercmp(&ms->touch[i].down, &ms->touch[earliest].down, <))
 				earliest = i;
@@ -350,6 +350,10 @@ static void buttons_update(struct Gestures* gs,
 					trigger_button_emulation(gs, cfg->button_2touch - 1);
 				else if (touching == 3 && cfg->button_3touch > 0)
 					trigger_button_emulation(gs, cfg->button_3touch - 1);
+			}
+			else if (touching == 0 && cfg->button_0touch > 0) {
+				LOG_EMULATED("buttons_update: integrated clicked without touch detection%d\n", touching);
+				trigger_button_emulation(gs, cfg->button_0touch - 1);
 			}
 		}
 	} /* if (down)*/

--- a/src/gestures.c
+++ b/src/gestures.c
@@ -351,8 +351,11 @@ static void buttons_update(struct Gestures* gs,
 				else if (touching == 3 && cfg->button_3touch > 0)
 					trigger_button_emulation(gs, cfg->button_3touch - 1);
 			}
-			else if (touching == 0 && cfg->button_0touch > 0) {
-				LOG_EMULATED("buttons_update: integrated clicked without touch detection%d\n", touching);
+			else if (cfg->button_0touch > 0) {
+				/* The integrated physical button have been pressed but no finger are valid
+				*  This code path can be reached by enabling the ClickFinger0 in the config file. 
+				*/
+				LOG_EMULATED("buttons_update: integrated pressed without touch detection%d\n", touching);
 				trigger_button_emulation(gs, cfg->button_0touch - 1);
 			}
 		}

--- a/src/gestures.c
+++ b/src/gestures.c
@@ -353,8 +353,7 @@ static void buttons_update(struct Gestures* gs,
 			}
 			else if (cfg->button_0touch > 0) {
 				/* The integrated physical button have been pressed but no finger are valid
-				*  This code path can be reached by enabling the ClickFinger0 in the config file. 
-				*/
+				 * This code path can be reached by enabling the ClickFinger0 in the config file. */
 				LOG_EMULATED("buttons_update: integrated pressed without touch detection%d\n", touching);
 				trigger_button_emulation(gs, cfg->button_0touch - 1);
 			}

--- a/src/mconfig.c
+++ b/src/mconfig.c
@@ -44,6 +44,7 @@ void mconfig_defaults(struct MConfig* cfg)
 	cfg->button_integrated = DEFAULT_BUTTON_INTEGRATED;
 	cfg->button_expire = DEFAULT_BUTTON_EXPIRE;
 	cfg->button_zones = DEFAULT_BUTTON_ZONES;
+	cfg->button_0touch = DEFAULT_BUTTON_0TOUCH;
 	cfg->button_1touch = DEFAULT_BUTTON_1TOUCH;
 	cfg->button_2touch = DEFAULT_BUTTON_2TOUCH;
 	cfg->button_3touch = DEFAULT_BUTTON_3TOUCH;
@@ -203,6 +204,7 @@ void mconfig_configure(struct MConfig* cfg,
 	cfg->button_integrated = xf86SetBoolOption(opts, "ButtonIntegrated", DEFAULT_BUTTON_INTEGRATED);
 	cfg->button_expire = MAXVAL(xf86SetIntOption(opts, "ButtonTouchExpire", DEFAULT_BUTTON_EXPIRE), 0);
 	cfg->button_zones = xf86SetBoolOption(opts, "ButtonZonesEnable", DEFAULT_BUTTON_ZONES);
+	cfg->button_0touch = CLAMPVAL(xf86SetIntOption(opts, "ClickFinger0", DEFAULT_BUTTON_0TOUCH), 0, 32);
 	cfg->button_1touch = CLAMPVAL(xf86SetIntOption(opts, "ClickFinger1", DEFAULT_BUTTON_1TOUCH), 0, 32);
 	cfg->button_2touch = CLAMPVAL(xf86SetIntOption(opts, "ClickFinger2", DEFAULT_BUTTON_2TOUCH), 0, 32);
 	cfg->button_3touch = CLAMPVAL(xf86SetIntOption(opts, "ClickFinger3", DEFAULT_BUTTON_3TOUCH), 0, 32);


### PR DESCRIPTION
As of now, it is not possible to click the integrated button on any "Edge" if __no__ finger are touching the "valid zone". 
[I made a gif exemple](https://imgur.com/a/jIGdS)  
The first commit change that.  
* Added an option `button_0touch` which default to "0". 
* Added an if statement to start a `trigger_button_emulation` when no finger touch the pad (or invalid) and a click is detected on the integrated button in `gesture.c  buttons_update()`.
* Added compilation files in .gitignore  

  
The second commit is simply a .conf file and a small usage edit in the README for the option from [first commit](b07caaf).