### PR TITLE
Update Readme to include possible build dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,9 @@ xorg module directory. Otherwise mtrack may be not installed in xserver search
 path.
 See `configure --help` for options.
 
+On Debian systems (including Ubuntu) you may also need to install the `xorg-dev`
+package prior to these commands.
+
 To build deb package and install in system wide you will usually have to change
 installation prefix to /usr like so:
 ```


### PR DESCRIPTION
`configure` complained: 
```
configure: error: Package requirements (xorg-server >= 1.7 xproto inputproto ) were not met:

No package 'xorg-server' found
```
which was resolved on ElementaryOS Juno (essentially Ubuntu 18.04) by `sudo apt-get install xorg-dev`.