### PR TITLE
Update required_packages.txt

### DIFF
--- a/required_packages.txt
+++ b/required_packages.txt
@@ -1,1 +1,1 @@
-xserver-xorg-dev mtdev-dev xutils-dev
+xserver-xorg-dev mtdev-dev libmtdev-dev xutils-dev


### PR DESCRIPTION
mtdev-dev is not found on ubuntu. Instead it is libmtdev-dev