### PR TITLE
Added ScrollCoastNoBoost and ScrollCoastEase options

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,16 +148,16 @@ Integer value. Defaults to 70.
 
 ---
 #### Zones<a name="Zones"></a>
-Divide the touchpad into "zones". Clicking the integrated button in one of 
-these zones will send the button event configured for each {First, Second, Third}ZoneButton. 
+Divide the touchpad into "zones". Clicking the integrated button in one of
+these zones will send the button event configured for each {First, Second, Third}ZoneButton.
 The driver will only add zones for the ZoneButton values that
-are enabled. The zone splitting start from the left to right using the first to third value. 
+are enabled. The zone splitting start from the left to right using the first to third value.
 So enabling only SecondZoneButton and ThirdZoneButton will create two
 zones, the left-middle part will fire SecondZoneButton and the middle-right part ThirdZoneButton.  
 
 **[ButtonZonesEnable](#ButtonZonesEnable)**<a name="ButtonZonesEnable"></a>
 Whether or not to enable button zones. If button zones are enabled then the
-trackpad will be split into one, two, or three vertical zones. 
+trackpad will be split into one, two, or three vertical zones.
 Boolean value. Defaults to false.
 
 **[FirstZoneButton](#FirstZoneButton)**<a name="FirstZoneButton"></a>
@@ -273,17 +273,17 @@ click is triggered.
 Integer value. Defaults to 150.
 
 **[ScrollClickTime](#ScrollClickTime)**<a name="ScrollClickTime"></a>
-For two finger scrolling. How long button triggered by scrolling 
+For two finger scrolling. How long button triggered by scrolling
 will be hold down. A value of 0 will hold button down till end of gesture.
 0 - emit button click only once pre "instance" of gesture.
 Integer value representing milliseconds.  
 Integer value. Defaults to 20.
 
 **[ScrollSensitivity](#ScrollSensitivity)**<a name="ScrollSensitivity"></a>
-For two finger scrolling. Sensitivity (movement speed) of pointer during two 
+For two finger scrolling. Sensitivity (movement speed) of pointer during two
 finger scrolling. A value of 0 disables pointer movement during gesture.
 Integer value expressed as parts per thousand of normal sensivity.
-A value of 1000 results with normal movement speed. 
+A value of 1000 results with normal movement speed.
 Integer value. Defaults to 0.
 
 **[ScrollUpButton](#ScrollUpButton)**<a name="ScrollUpButton"></a>
@@ -308,7 +308,7 @@ Boolean value. Defaults to 1.
 Property: "Trackpad High Smooth Scroll"
 
 **[ScrollCoastDuration](#ScrollCoastDuration)**<a name="ScrollCoastDuration"></a>
-How long after finished scrolling movement should be continued. Works only 
+How long after finished scrolling movement should be continued. Works only
 with smooth scrolling enabled.  
 Floating value representing miliseconds. Defaults to 200.0.
 Property: "Trackpad Scroll Coasting"
@@ -316,6 +316,16 @@ Property: "Trackpad Scroll Coasting"
 **[ScrollCoastEnableSpeed](#ScrollCoastEnableSpeed)**<a name="ScrollCoastEnableSpeed"></a>
 How fast scroll should be to enable coasting feature.  
 Floating value. Defaults to 0.1.
+Property: "Trackpad Scroll Coasting"
+
+**[ScrollCoastNoBoost](#ScrollCoastNoBoost)**<a name="ScrollCoastNoBoost"></a>
+Disable boosting on second scroll gesture during coasting
+Boolean value. Defaults to false.
+Property: "Trackpad Scroll Coasting"
+
+**[ScrollCoastEase](#ScrollCoastEase)**<a name="ScrollCoastEase"></a>
+Apply easing effect on coasting
+Boolean value. Defaults to false.
 Property: "Trackpad Scroll Coasting"
 
 ---
@@ -331,7 +341,7 @@ will be hold down.
 Integer value representing milliseconds. Defaults to 300.
 
 **[SwipeSensitivity](#SwipeSensitivity)**<a name="SwipeSensitivity"></a>
-For three finger scrolling. Sensitivity (movement speed) of pointer during three 
+For three finger scrolling. Sensitivity (movement speed) of pointer during three
 finger scrolling. A value of 0 disables pointer movement during gesture.  
 Integer value expressed as parts per thousand of normal sensivity.  
 A value of 1000 results with normal movement speed. Defaults to 0.
@@ -365,7 +375,7 @@ will be hold down.
 Integer value representing milliseconds. Defaults to 300.
 
 **[Swipe4Sensitivity](#Swipe4Sensitivity)**<a name="Swipe4Sensitivity"></a>
-For four finger scrolling. Sensitivity (movement speed) of pointer during four 
+For four finger scrolling. Sensitivity (movement speed) of pointer during four
 finger scrolling. A value of 0 disables pointer movement during gesture.  
 Integer value expressed as parts per thousand of normal sensivity.  
 A value of 1000 results with normal movement speed. Defaults to 0.
@@ -487,7 +497,7 @@ Integer value representing a percentage of the total trackpad width. Defaults to
 ---
 #### Special features
 **[Hold1Move1StationaryButton](#Hold1Move1StationaryButton)**<a name="Hold1Move1StationaryButton"></a>
-For two finger hold-and-move functionality. The button that is triggered by 
+For two finger hold-and-move functionality. The button that is triggered by
 holding one finger and moving another one.  
 Integer value. A value of 0 disables hold-and-move.  
 Value of 0 disables this functionality.  
@@ -561,7 +571,7 @@ Gesture will last as long as fist finger (a.k.a. stationary finger) will
 be held down in place.
 
 Increase [TapDragDist](#TapDragDist) to give stationary finger more freedom.
-Set [Hold1Move1StationaryButton](#Hold1Move1StationaryButton) to 0 to disable, set to other value to send button other 
+Set [Hold1Move1StationaryButton](#Hold1Move1StationaryButton) to 0 to disable, set to other value to send button other
 than "1".
 
 #### Persistent dragging

--- a/driver/mtrack.c
+++ b/driver/mtrack.c
@@ -353,8 +353,8 @@ CARD32 mt_timer_callback(OsTimerPtr timer, CARD32 time, void *arg)
 		delta_ms = mt->cfg.scroll_coast.tick_ms;
 		if (mt->cfg.scroll_coast.ease) {
 			/* Calculate easing effect */
-			coasting_progress = ((double)mt->cfg.scroll_coast.duration - gs->coasting_duration_left) / (double)mt->cfg.scroll_coast.duration;
-			delta_ms = delta_ms - ((delta_ms * coasting_progress) / 2);
+			coasting_progress = 1 - gs->coasting_duration_left / (double)mt->cfg.scroll_coast.duration;
+			delta_ms = delta_ms - (delta_ms * coasting_progress / 2);
 			coasting_progress = (cos(PI * coasting_progress) + 1) / 2;
 		}
 		else

--- a/include/mconfig.h
+++ b/include/mconfig.h
@@ -69,6 +69,8 @@
 #define DEFAULT_SCROLL_COAST_MIN_SPEED 0.1f
 #define DEFAULT_SCROLL_COAST_DURATION 200
 #define DEFAULT_SCROLL_COAST_TICK_MS 30 /* Schould be configurable? */
+#define DEFAULT_SCROLL_COAST_NO_BOOST 0
+#define DEFAULT_SCROLL_COAST_EASE 0
 #define DEFAULT_SWIPE_DIST 700
 #define DEFAULT_SWIPE_UP_BTN 8
 #define DEFAULT_SWIPE_DN_BTN 9
@@ -198,6 +200,8 @@ struct MConfig {
 		float min_speed;		// What speed to start scroll coasting at. >= 0
 		int tick_ms;		// How fast events will be generated during coasting >= 1
 		int duration;		// How long coasting ticks will last >= 0, 0 disables coasting
+		int no_boost;		// Disable boosting on second scroll gesture during coasting. 0 or 1
+		int ease;				// Apply easing effect on coasting. 0 or 1
 	} scroll_coast;
 	struct MConfigSwipe edge_scroll;
 	int scale_dist;			// Distance needed to trigger a button. >= 0, 0 disables
@@ -242,4 +246,3 @@ void mconfig_configure(struct MConfig* cfg,
 			pointer opts);
 
 #endif
-

--- a/src/gestures.c
+++ b/src/gestures.c
@@ -315,7 +315,7 @@ static void buttons_update(struct Gestures* gs,
 
 /*
  * Handle the physical button click in relation to touch properties.
- * It count the number of valid finger touching the pad while clicking it to 
+ * It count the number of valid finger touching the pad while clicking it to
  * emulate the action in the user config. See "ClickFinger#" configuration parameter.
 */
 static void touch_detect_update(
@@ -324,7 +324,7 @@ static void touch_detect_update(
 	const struct MTState* ms,
 	int latest)
 {
-	int i = 0, 
+	int i = 0,
 	touching = 0;
 	struct timeval expire;
 
@@ -741,8 +741,12 @@ static int trigger_swipe_unsafe(struct Gestures* gs,
 		gs->scroll_speed_valid = 1;
 		LOG_INFO2(DISABLED, "smooth scrolling: speed: x: %lf, y: %lf\n", gs->scroll_speed_x, gs->scroll_speed_y);
 
-		/* Reset coasting duration 'to go' ticks. */
-		gs->coasting_duration_left = cfg->scroll_coast.duration - 1;
+		if (cfg->scroll_coast.no_boost)
+			/* Prevent scroll coasting boost */
+			gs->coasting_duration_left = 0;
+		else
+			/* Reset coasting duration 'to go' ticks. */
+			gs->coasting_duration_left = cfg->scroll_coast.duration - 1;
 
 		/* Don't modulo move_dist */
 	}

--- a/src/mconfig.c
+++ b/src/mconfig.c
@@ -71,6 +71,8 @@ void mconfig_defaults(struct MConfig* cfg)
 	cfg->scroll_coast.min_speed = DEFAULT_SCROLL_COAST_MIN_SPEED;
 	cfg->scroll_coast.tick_ms = DEFAULT_SCROLL_COAST_TICK_MS;
 	cfg->scroll_coast.duration = DEFAULT_SCROLL_COAST_DURATION;
+	cfg->scroll_coast.no_boost = DEFAULT_SCROLL_COAST_NO_BOOST;
+	cfg->scroll_coast.ease = DEFAULT_SCROLL_COAST_EASE;
 	cfg->swipe3.dist = DEFAULT_SWIPE_DIST;
 	cfg->swipe3.hold = DEFAULT_SWIPE_HOLD;
 	cfg->swipe3.drag_sens = DEFAULT_SWIPE_SENS;
@@ -237,6 +239,8 @@ void mconfig_configure(struct MConfig* cfg,
 	cfg->scroll_coast.min_speed = MAXVAL(xf86SetRealOption(opts, "ScrollCoastEnableSpeed", DEFAULT_SCROLL_COAST_MIN_SPEED), 0.0);
 	cfg->scroll_coast.tick_ms = MAXVAL(DEFAULT_SCROLL_COAST_TICK_MS, 1);
 	cfg->scroll_coast.duration = MAXVAL(xf86SetRealOption(opts, "ScrollCoastDuration", DEFAULT_SCROLL_COAST_DURATION), 0);
+	cfg->scroll_coast.no_boost = xf86SetBoolOption(opts, "ScrollCoastNoBoost", DEFAULT_SCROLL_COAST_NO_BOOST);
+	cfg->scroll_coast.ease = xf86SetBoolOption(opts, "ScrollCoastEase", DEFAULT_SCROLL_COAST_EASE);
 	cfg->swipe3.dist = MAXVAL(xf86SetIntOption(opts, "SwipeDistance", DEFAULT_SWIPE_DIST), 1);
 	cfg->swipe3.hold = MAXVAL(xf86SetIntOption(opts, "SwipeClickTime", DEFAULT_SWIPE_HOLD), 0);
 	cfg->swipe3.drag_sens = MAXVAL(xf86SetIntOption(opts, "SwipeSensitivity", DEFAULT_SWIPE_SENS), 0);


### PR DESCRIPTION
Please consider following patch:
1.  Added `ScrollCoastNoBoost` option, which prevents speed multiplication on subsequent scroll gestures while coasting still running. This behaviour was mentioned in following issues: #99 #59.
Boolean value, default `false`.
2. Added `ScrollCoastEase` option, which applying `ease` effect on coasting movement and creating non-linear slow down. Close to [easeInOutCubic](https://easings.net/#easeInOutCubic) logic.
Boolean value, default `false`.

To test this options, please set:
```
Option "GestureClickTime" "20"
Option "GestureWaitTime" "50"
Option "ScrollSmooth" "true"
Option "ScrollCoastDuration" "1000"
Option "ScrollCoastEnableSpeed" "0.05"
Option "ScrollCoastNoBoost" "true"
Option "ScrollCoastEase" "true"
Option "ScrollDistance" "650"
Option "ScrollClickTime" "5"
```
_* Last two options depends on your touchpad hardware._
_** To enable smooth scrolling and coasting controlled by xinput in Firefox, add following env:_ `MOZ_USE_XINPUT2=1`

Patch was tested on Arch Linux @ MacBookPro Late 2014.