### PR TITLE
Support palm rejection on some "minimal capability" trackpads

### DIFF
--- a/include/hwstate.h
+++ b/include/hwstate.h
@@ -32,7 +32,7 @@ struct FingerState {
 	int width_major, width_minor;
 	int orientation, pressure;
 	int position_x, position_y;
-	int tracking_id;
+	int tracking_id, tool_type;
 };
 
 struct HWState {

--- a/include/mconfig.h
+++ b/include/mconfig.h
@@ -122,6 +122,7 @@
 #define MCFG_PRESSURE_SIZE 3
 #define MCFG_SIZE_PRESSURE 4 /* same capabilities as above, but with higher resolution of touches*/
 #define MCFG_PRESSURE 5
+#define MCFG_DUMB_PALM 6
 
 struct MConfig {
 	/* Used by MTState */

--- a/src/hwstate.c
+++ b/src/hwstate.c
@@ -112,6 +112,9 @@ static int read_event(struct HWState *s, const struct Capabilities *caps,
 			s->data[s->slot].tracking_id = ev->value;
 			MODBIT(s->used, s->slot, ev->value != MT_ID_NULL);
 			break;
+		case ABS_MT_TOOL_TYPE:
+			s->data[s->slot].tool_type = ev->value;
+			break;
 		}
 		break;
 	}

--- a/src/mconfig.c
+++ b/src/mconfig.c
@@ -179,6 +179,11 @@ void mconfig_init(struct MConfig* cfg,
 		LOG_INFO("Touchpad is pressure based.\n");
 		LOG_INFO("  pressure_min = %d, pressure_max = %d\n", cfg->pressure_min, cfg->pressure_max);
 	}
+	else if (caps->has_mtdata && caps->has_abs[ABS_MT_TOOL_TYPE])
+	{
+		cfg->touch_type = MCFG_DUMB_PALM;
+		LOG_WARNING("Touchpad only supports multitouch and palm rejection.\n");
+	}
 	else {
 		cfg->touch_type = MCFG_NONE;
 		LOG_WARNING("Touchpad has minimal capabilities. Some features will be unavailable.\n");

--- a/src/mtstate.c
+++ b/src/mtstate.c
@@ -115,6 +115,12 @@ static int is_palm(const struct MConfig* cfg,
 	case MCFG_PRESSURE:
 		ratio =  pressure_range_ratio(cfg, hw->pressure);
 		break;
+	case MCFG_DUMB_PALM:
+	  if(hw->tool_type > 0)
+		{
+		  ratio = cfg->palm_size+1;
+			break;
+		}
 	default:
 		return 0;
 	}
@@ -392,4 +398,3 @@ void mtstate_extract(struct MTState* ms,
 	mtstate_output(ms, hs);
 #endif
 }
-


### PR DESCRIPTION
I recently purchased a System76 Pangolin (pang11), which is a rebranded Clevo NL50NU. I started using xf86-input-mtrack for inertial scrolling support, but found that several features don't work with my touchpad. One such feature was palm rejection. The touchpad on my computer identifies as

    FTCS1000:00 2808:0101 Touchpad

After using `evtest`, I noticed this this touchpad is, well, pretty dumb. The only things that it really supports is absolute value multi-touch (no pressure, touch size, etc.) and the multitouch "TOOL_TYPE" property. The TOOL_TYPE property is changed when the touchpad detects a palm. On a normal touch, the value is TOOL_TYPE=0, but when a palm is placed on the touchpad, it shows TOOL_TYPE=2. I haven't figured out if TOOL_TYPE=1 is even possible, but despite my efforts, I have yet to see it.

That means, that for this touchpad, normal palm rejection won't work properly -- there is no size attribute given to calculate a palm ratio. So, I modified the driver to take into account the TOOL_TYPE for palm rejection on this dumb trackpad. The changes only apply to trackpads without pressure/size information and that also expose a TOOL_TYPE attribute.

Of course, this is tested and working on my trackpad now.

Trackpad information:

```
$ ./mtrack-test /dev/input/event12
mtrack[1] src/capabilities.c:196: Capabilities: 
mtrack[...]: devname: FTCS1000:00 2808:0101 Touchpad
mtrack[...]: devid: 2808 101 100
mtrack[...]: ABS_MT_POSITION_X: min: 0 max: 1481
mtrack[...]: ABS_MT_POSITION_Y: min: 0 max: 911
mtrack[...]: ABS_MT_TOOL_TYPE: min: 0 max: 2
mtrack[...]: ABS_MT_TRACKING_ID: min: 0 max: 65535
mtrack[...]: ABS_MT_SLOT: min: 0 max: 4
mtrack[...]: enabled caps: left mtdata slot
mtrack[1] src/mconfig.c:185: Touchpad only supports multitouch and palm rejection.
width:  1481
height: 911
```